### PR TITLE
require set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Syntax: a syntax highlighting library for Ruby.
 
+1.2.1 In Progress
+  Added missing require - @jberkel.
+
 1.2.0 02 Jan 2014
   Cleaned up Gemspec, added license and homepage - @grosser.
 

--- a/lib/syntax/lang/ruby.rb
+++ b/lib/syntax/lang/ruby.rb
@@ -1,4 +1,5 @@
 require 'syntax'
+require 'set'
 
 module Syntax
 


### PR DESCRIPTION
from our CI logs

```
uninitialized constant Syntax::Ruby::Set (NameError)
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/syntax-1.2.0/lib/syntax/lang/ruby.rb:12:in `<class:Ruby>'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/syntax-1.2.0/lib/syntax/lang/ruby.rb:8:in `<module:Syntax>'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/syntax-1.2.0/lib/syntax/lang/ruby.rb:3:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/syntax-1.2.0/lib/syntax.rb:24:in `load'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/syntax-1.2.0/lib/syntax/convertors/abstract.rb:16:in `for_syntax'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/cucumber-1.3.14/lib/cucumber/formatter/html.rb:580:in `<class:SnippetExtractor>'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/cucumber-1.3.14/lib/cucumber/formatter/html.rb:578:in `<class:Html>'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/cucumber-1.3.14/lib/cucumber/formatter/html.rb:8:in `<module:Formatter>'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/cucumber-1.3.14/lib/cucumber/formatter/html.rb:7:in `<module:Cucumber>'
/Users/ci/.jenkins/workspace/soundcloud_rac_master/vendor/bundle/ruby/2.0.0/gems/cucumber-1.3.14/lib/cucumber/formatter/html.rb:6:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
```
