### PR TITLE
Improve frozen-string-literals compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: ruby
-rvm:
-  - 1.8.7-p374
-  - 1.9.2-p330
-  - 1.9.3-p551
-  - 2.0.0-p648
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - jruby-18mode
-  - jruby-19mode
-  - jruby-9.1.12.0
+matrix:
+  include:
+    - rvm: 1.8.7-p374
+    - rvm: 1.9.2-p330
+    - rvm: 1.9.3-p551
+    - rvm: 2.0.0-p648
+    - rvm: 2.1.10
+    - rvm: 2.2.7
+    - rvm: 2.3.4
+    - rvm: 2.4.1
+      env: RUBYOPT=--enable-frozen-string-literal
+    - rvm: jruby-18mode
+    - rvm: jruby-19mode
+    - rvm: jruby-9.1.12.0
 sudo: false
-before_script:
-- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ rvm:
   - jruby-19mode
   - jruby-9.1.12.0
 sudo: false
+before_script:
+- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Syntax: a syntax highlighting library for Ruby.
 
 Unreleased
   Add Travis CI configuration - @pat.
+  Updates to work with frozen string literals - @pat.
 
 1.2.1 01 June 2016
   Explicitly require 'set' - @jberkel.

--- a/lib/syntax/common.rb
+++ b/lib/syntax/common.rb
@@ -40,7 +40,7 @@ module Syntax
     # such as creating a new scanner for the text and saving the callback block.
     # The block will be invoked for each token extracted.
     def start( text, &block )
-      @chunk = ""
+      @chunk = "".dup
       @group = :normal
       @callback = block
       @text = StringScanner.new( text )
@@ -148,7 +148,7 @@ module Syntax
 
       def flush_chunk
         @callback.call( Token.new( @chunk, @group ) ) unless @chunk.empty?
-        @chunk = ""
+        @chunk = "".dup
       end
 
       def subtokenize( syntax, text )

--- a/lib/syntax/convertors/html.rb
+++ b/lib/syntax/convertors/html.rb
@@ -10,7 +10,7 @@ module Syntax
       # of any type but <tt>:normal</tt> (which is always unhighlighted). If
       # +pre+ is +true+, the html is automatically wrapped in pre tags.
       def convert( text, pre=true )
-        html = ""
+        html = "".dup
         html << "<pre>" if pre
         regions = []
         @tokenizer.tokenize( text ) do |tok|

--- a/lib/syntax/lang/ruby.rb
+++ b/lib/syntax/lang/ruby.rb
@@ -218,7 +218,7 @@ module Syntax
 
         start_region inner_group
 
-        items = "\\\\|"
+        items = "\\\\|".dup
         if heredoc
           items << "(^"
           items << '\s*' if heredoc == :float
@@ -273,7 +273,7 @@ module Syntax
                 case matched[1]
                   when ?{
                     depth = 1
-                    content = ""
+                    content = "".dup
                     while depth > 0
                       p = pos
                       c = scan_until( /[\{}]/ )


### PR DESCRIPTION
Some changes to ensure `syntax` is happy to run when the `--enable-frozen-string-literal` flag is in place via `RUBYOPT` when using MRI 2.4. The tests passed for me locally both before and after these changes.

I realise this is a bit of a surprising patch for a library that's built with MRI 1.9, but I've followed the path of dependencies from rspec to cucumber to here, patching as I go :)

Also: I've opted for `"".dup` instead of `String.new`, because the latter has an ASCII encoding, whereas `String.new("")` respects the argument's encoding (UTF-8 in recent MRI releases). Happy to tweak things if you've a preferred syntax.