### PR TITLE
Travis CI Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 pkg
 api
 doc/manual-html
-
-
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+  - 1.8.7-p374
+  - 1.9.2-p330
+  - 1.9.3-p551
+  - 2.0.0-p648
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-9.1.12.0
+sudo: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Syntax: a syntax highlighting library for Ruby.
 
+Unreleased
+  Add Travis CI configuration - @pat.
+
 1.2.1 01 June 2016
   Explicitly require 'set' - @jberkel.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem "rdoc",      "4.2.2", :platform => [:ruby_18, :ruby_19]
-gem "test-unit", "3.1.5", :platform => [:ruby_18]
+
+if RUBY_VERSION.to_f < 2.2
+  gem "test-unit", "3.1.5", :platform => [:ruby_18]
+else
+  gem "test-unit", ">= 3.2.5"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rdoc",      "4.2.2", :platform => [:ruby_18, :ruby_19]
+gem "test-unit", "3.1.5", :platform => [:ruby_18]

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,9 @@
-require 'rubygems/builder'
+begin
+  require 'rubygems/builder'
+rescue LoadError
+  puts "rubygems/builder could not be required."
+end
+
 require 'rake'
 require 'rake/testtask'
 require 'rdoc/task'

--- a/syntax.gemspec
+++ b/syntax.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "syntax", Syntax::Version::STRING do |s|
   s.homepage = "https://github.com/dblock/syntax"
   s.license = "BSD"
 
-  s.add_development_dependency "rake"
+  s.add_development_dependency "rake", "< 11.0.0"
   s.add_development_dependency "rake-contrib"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "test-unit"

--- a/syntax.gemspec
+++ b/syntax.gemspec
@@ -11,5 +11,6 @@ Gem::Specification.new "syntax", Syntax::Version::STRING do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rake-contrib"
+  s.add_development_dependency "rdoc"
   s.add_development_dependency "test-unit"
 end

--- a/syntax.gemspec
+++ b/syntax.gemspec
@@ -8,4 +8,8 @@ Gem::Specification.new "syntax", Syntax::Version::STRING do |s|
   s.email = "jamis@jamisbuck.org"
   s.homepage = "https://github.com/dblock/syntax"
   s.license = "BSD"
+
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rake-contrib"
+  s.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
Runs on MRI 1.8.7 through to 2.4.1, plus JRubies. You'll want to enable Travis CI for your repo first before merging this in, to confirm it's green after the merge.

My passing build for this branch: https://travis-ci.org/pat/syntax/builds/248176527